### PR TITLE
fix: sing-box "unsafe" fingerprint guard and CipherSuites resets (follow-up to #1)

### DIFF
--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -716,6 +716,7 @@ public static class ConfigHandler
         profileItem.Fingerprint = string.Empty;
         profileItem.Alpn = string.Empty;
         //profileItem.Alpn = "h3";
+        profileItem.CipherSuites = string.Empty;
         profileItem.Network = string.Empty;
 
         if (profileItem.StreamSecurity.IsNullOrEmpty())
@@ -918,6 +919,7 @@ public static class ConfigHandler
         profileItem.Password = profileItem.Password.TrimEx();
         profileItem.Fingerprint = string.Empty;
         profileItem.Alpn = string.Empty;
+        profileItem.CipherSuites = string.Empty;
         profileItem.Network = string.Empty;
         profileItem.AllowInsecure = string.Empty;
         if (profileItem.StreamSecurity.IsNullOrEmpty())

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -422,7 +422,8 @@ public partial class CoreConfigSingboxService
                 insecure = _node.GetAllowInsecure(),
                 alpn = _node.GetAlpn(),
             };
-            if (_node.Fingerprint.IsNotEmpty())
+            // "unsafe" is an Xray-only fingerprint; sing-box's uTLS rejects it, so fall back to plain TLS
+            if (_node.Fingerprint.IsNotEmpty() && _node.Fingerprint != "unsafe")
             {
                 tls.utls = new Utls4Sbox()
                 {


### PR DESCRIPTION
Follow-up to #1, which added the `cipherSuites` TLS option and the `unsafe` fingerprint. That PR was largely complete (all 8 locales, both WPF and Avalonia layouts, DB column auto-migrates via sqlite-net), but an audit found two behavioral gaps.

## What changed

- **sing-box `unsafe` fingerprint guard** (`SingboxOutboundService.cs`): `unsafe` is an Xray-only fingerprint. sing-box passes the node fingerprint into `tls.utls.fingerprint` and rejects unknown uTLS names at startup, so any node with fingerprint `unsafe` running on the sing-box core failed to connect. Also reachable indirectly: `AddServerCommon` stamps the global default fingerprint (settable to `unsafe` in the options window) onto REALITY nodes with an empty fingerprint. uTLS is now skipped when the fingerprint is `unsafe` — plain Go TLS is also what Xray's `unsafe` semantically means, so behavior converges across cores.
- **`CipherSuites` resets for Hysteria2/Naive** (`ConfigHandler.cs`): #1 disabled `txtCipherSuites` for these protocols but their add/save paths only reset `Fingerprint`/`Alpn`, leaving stale `CipherSuites` values in the database. The reset is added alongside the existing ones.

## Considered and deliberately not changed

- `CompareProfileItem` doesn't compare `CipherSuites`: the function consistently excludes manual-only fields (`EchConfigList`, `VerifyPeerCertByName`, `Cert`) and also drives active-node re-selection and traffic-stats preservation across subscription updates, where new items can never carry `cipherSuites`. Adding it would break re-matching of manually edited subscription items.
- TUIC/Anytls keep `txtCipherSuites` enabled despite being sing-box-only — matches existing precedent (`verifyPeerCertByName`, also Xray-only, stays enabled for them).
- `unsafe` + REALITY on Xray: the shared fingerprint combos offer `unsafe` for REALITY where Xray may reject it; validation is left to the core.

`ServiceLib` builds cleanly with these changes (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
