### PR TITLE
feat: complete CipherSuites support - share links, VMess QR code, sing-box TLS

### DIFF
--- a/v2rayN/ServiceLib/Handler/Fmt/BaseFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/BaseFmt.cs
@@ -67,6 +67,10 @@ public class BaseFmt
             {
                 dicQuery.Add("alpn", Utils.UrlEncode(item.Alpn));
             }
+            if (item.CipherSuites.IsNotEmpty())
+            {
+                dicQuery.Add("cs", Utils.UrlEncode(item.CipherSuites));
+            }
             ToUriQueryAllowInsecure(item, ref dicQuery);
         }
         if (item.EchConfigList.IsNotEmpty())
@@ -225,6 +229,7 @@ public class BaseFmt
         item.StreamSecurity = GetQueryValue(query, "security");
         item.Sni = GetQueryValue(query, "sni");
         item.Alpn = GetQueryDecoded(query, "alpn");
+        item.CipherSuites = GetQueryDecoded(query, "cs");
         item.Fingerprint = GetQueryDecoded(query, "fp");
         item.PublicKey = GetQueryDecoded(query, "pbk");
         item.ShortId = GetQueryDecoded(query, "sid");

--- a/v2rayN/ServiceLib/Handler/Fmt/VmessFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/VmessFmt.cs
@@ -66,6 +66,7 @@ public class VmessFmt : BaseFmt
             sni = item.Sni,
             alpn = item.Alpn,
             fp = item.Fingerprint,
+            cs = item.CipherSuites,
             insecure = item.GetAllowInsecure() ? "1" : "0",
             vcn = item.VerifyPeerCertByName,
             pcs = item.CertSha
@@ -142,6 +143,7 @@ public class VmessFmt : BaseFmt
         item.Sni = Utils.ToString(vmessQRCode.sni);
         item.Alpn = Utils.ToString(vmessQRCode.alpn);
         item.Fingerprint = Utils.ToString(vmessQRCode.fp);
+        item.CipherSuites = Utils.ToString(vmessQRCode.cs);
         item.AllowInsecure = vmessQRCode.insecure == "1" ? Global.StringTrue : string.Empty;
         item.VerifyPeerCertByName = Utils.ToString(vmessQRCode.vcn);
         item.CertSha = Utils.ToString(vmessQRCode.pcs);

--- a/v2rayN/ServiceLib/Models/Dto/VmessQRCode.cs
+++ b/v2rayN/ServiceLib/Models/Dto/VmessQRCode.cs
@@ -39,6 +39,8 @@ public class VmessQRCode
 
     public string fp { get; set; } = string.Empty;
 
+    public string cs { get; set; } = string.Empty;
+
     public string insecure { get; set; } = string.Empty;
 
     public string vcn { get; set; } = string.Empty;


### PR DESCRIPTION
Follow-up to #1/#2, and the v2rayN counterpart of patterniha/v2rayNG#3. Completes `CipherSuites` support everywhere `Fingerprint`/`Alpn` are handled.

## What changed

**Share-link / QR-code round-trip** — the fork already round-trips its custom TLS fields (`ech`, `vcn`, `pcs`, `pqv`) but `CipherSuites` was missing, so sharing a profile silently dropped it:
- `BaseFmt.ToUriQuery`: exports a `cs` query parameter inside the TLS-only block alongside `alpn` (cipher suites don't apply to REALITY).
- `BaseFmt.ResolveUriQuery`: imports `cs` for all URL-based protocols.
- `VmessQRCode` + `VmessFmt`: `cs` field mapped in both directions.
- The `cs` key matches the v2rayNG fork (patterniha/v2rayNG#3), so links interop between the two clients.

**sing-box core support** — sing-box supports `cipher_suites` on outbound TLS (a list of the same Go TLS names Xray takes as a colon-separated string), so the setting no longer silently does nothing on the sing-box core:
- `Tls4Sbox`: new `cipher_suites` field.
- `SingboxOutboundService.GenOutboundTls`: maps the stored string (split on `:` or `,`) in the TLS branch only; REALITY uses uTLS where cipher suites don't apply.

## Notes for reviewers

- Sites audited and deliberately left alone: `ToUriQueryLite` (used by Hysteria2/TUIC links, which follow their ecosystem's standard params), `CompareProfileItem` (excludes manual-only fields by convention), and the TUIC alpn default in `ConfigHandler` (protocol-specific).
- sing-box ignores `cipher_suites` for TLS 1.3 per its docs; that's inherent to the option.
- `ServiceLib` builds cleanly (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)