### PR TITLE
feat: apply CipherSuites to sing-box TLS outbounds

### DIFF
--- a/v2rayN/ServiceLib/Models/CoreConfigs/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/CoreConfigs/SingboxConfig.cs
@@ -184,6 +184,7 @@ public class Tls4Sbox
     public string? server_name { get; set; }
     public bool? insecure { get; set; }
     public List<string>? alpn { get; set; }
+    public List<string>? cipher_suites { get; set; }
     public Utls4Sbox? utls { get; set; }
     public Reality4Sbox? reality { get; set; }
     public bool? fragment { get; set; }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -433,6 +433,15 @@ public partial class CoreConfigSingboxService
             }
             if (_node.StreamSecurity == Global.StreamSecurity)
             {
+                if (_node.CipherSuites.IsNotEmpty())
+                {
+                    // Xray stores cipher suites as a colon-separated string; sing-box wants a list of the same Go TLS names
+                    tls.cipher_suites = _node.CipherSuites
+                        .Split([':', ','], StringSplitOptions.RemoveEmptyEntries)
+                        .Select(c => c.Trim())
+                        .Where(c => c.IsNotEmpty())
+                        .ToList();
+                }
                 var certs = CertPemManager.ParsePemChain(_node.Cert);
                 if (certs.Count > 0)
                 {


### PR DESCRIPTION
Picks up a commit stranded on `feat/cipher-suites-share-link`: it was pushed right after #3 had already been merged, so it never landed in master (same situation as patterniha/v2rayNG#3 earlier).

## What changed

sing-box supports `cipher_suites` on outbound TLS — a list of the same Go TLS names that Xray takes as a colon-separated string — so the `CipherSuites` setting no longer silently does nothing when a profile runs on the sing-box core (including TUIC/Anytls, where the field is editable).

- `Tls4Sbox`: new `cipher_suites` field.
- `SingboxOutboundService.GenOutboundTls`: maps the stored string (split on `:` or `,`) in the TLS branch only; REALITY uses uTLS, where cipher suites don't apply.

Per sing-box docs, TLS 1.3 cipher suites are not configurable and the option is ignored for them; that's inherent to the option.

`ServiceLib` builds cleanly with this change (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)