### PR TITLE
Fix blank/generic dock icon for running windows on Linux (add StartupWMClass=PattN)

### DIFF
--- a/package-debian-loong.sh
+++ b/package-debian-loong.sh
@@ -536,6 +536,7 @@ Name=PattN
 Comment=PattN for Debian GNU Linux
 Exec=v2rayn
 Icon=v2rayn
+StartupWMClass=PattN
 Terminal=false
 Categories=Network;
 EOF

--- a/package-debian-riscv.sh
+++ b/package-debian-riscv.sh
@@ -534,6 +534,7 @@ Name=PattN
 Comment=PattN for Debian GNU Linux
 Exec=v2rayn
 Icon=v2rayn
+StartupWMClass=PattN
 Terminal=false
 Categories=Network;
 EOF

--- a/package-debian.sh
+++ b/package-debian.sh
@@ -548,6 +548,7 @@ Name=PattN
 Comment=PattN for Debian GNU Linux
 Exec=v2rayn
 Icon=v2rayn
+StartupWMClass=PattN
 Terminal=false
 Categories=Network;
 EOF

--- a/package-rhel-loong.sh
+++ b/package-rhel-loong.sh
@@ -572,6 +572,7 @@ Name=PattN
 Comment=PattN for Red Hat Enterprise Linux
 Exec=v2rayn
 Icon=v2rayn
+StartupWMClass=PattN
 Terminal=false
 Categories=Network;
 EOF

--- a/package-rhel-riscv.sh
+++ b/package-rhel-riscv.sh
@@ -571,6 +571,7 @@ Name=PattN
 Comment=PattN for Red Hat Enterprise Linux
 Exec=v2rayn
 Icon=v2rayn
+StartupWMClass=PattN
 Terminal=false
 Categories=Network;
 EOF

--- a/package-rhel.sh
+++ b/package-rhel.sh
@@ -560,6 +560,7 @@ Name=PattN
 Comment=PattN for Red Hat Enterprise Linux
 Exec=v2rayn
 Icon=v2rayn
+StartupWMClass=PattN
 Terminal=false
 Categories=Network;
 EOF


### PR DESCRIPTION
## Problem

On GNOME (Wayland), when PattN is running, the dock/taskbar shows a generic pictureless icon instead of the green PattN icon. The pinned launcher icon is fine — only the *running window's* icon is wrong.

## Root cause

PattN's Linux binary is named `PattN` (installed at `/opt/v2rayN/PattN`), so the running X11/XWayland window reports:

```
WM_CLASS = "PattN", "PattN"
_NET_WM_PID = 509237   (verified with xprop on a live PattN window)
```

But the packaged desktop entry is `/usr/share/applications/v2rayn.desktop` and contains no `StartupWMClass`. Desktop environments match a running window to its launcher icon by linking the window's WM_CLASS/app-id to a desktop file (via `StartupWMClass`, or by desktop-file basename). Since nothing links `PattN` → `v2rayn.desktop`, GNOME Shell cannot associate the window with the desktop entry and falls back to a generic icon.

(Upstream v2rayN doesn't hit this because its binary is named `v2rayN`, which case-insensitively matches the `v2rayn.desktop` basename.)

## Fix

Add `StartupWMClass=PattN` to the desktop entry generated by all Linux packaging scripts:

- package-debian.sh
- package-debian-loong.sh
- package-debian-riscv.sh
- package-rhel.sh
- package-rhel-loong.sh
- package-rhel-riscv.sh

One line per file, no other changes.

## Verification

- Confirmed on a live system (Fedora/RHEL, GNOME Wayland, PattN 7.24.8-P7 x64 installed from the RPM): the running window reports `WM_CLASS = "PattN"`.
- Adding `StartupWMClass=PattN` to the desktop entry makes GNOME merge the running window with the green PattN launcher icon (verified with a user-level override desktop entry before preparing this PR).
- All modified scripts pass `bash -n`.

Users can apply the same fix immediately without waiting for a new package, e.g.:

```sh
sudo sed -i '/^Icon=v2rayn$/a StartupWMClass=PattN' /usr/share/applications/v2rayn.desktop
```

then restart the app.

> Note: this replaces #12, which was closed accidentally and cannot be reopened by GitHub.